### PR TITLE
Fixed some things that annoyed me about earlier builds of this mod

### DIFF
--- a/plantmegapack/block/PMPBlockSapling.java
+++ b/plantmegapack/block/PMPBlockSapling.java
@@ -41,6 +41,7 @@ public class PMPBlockSapling
 		setSoundType(SoundType.PLANT);
 		GameRegistry.registerBlock(this, PMPItemSapling.class, this.treeData.sapling.name());
 		OreDictionary.registerOre(this.treeData.sapling.oreDictName, this);
+		OreDictionary.registerOre("treeSapling");
 	}
 	
 	public PMPTree getTree() {

--- a/plantmegapack/block/PMPBlockWoodFence.java
+++ b/plantmegapack/block/PMPBlockWoodFence.java
@@ -37,6 +37,7 @@ public class PMPBlockWoodFence
 		setHardness(1.2F);
 		GameRegistry.registerBlock(this, blockName + suffix);
 		OreDictionary.registerOre(oreDictName + suffix, this);
+		OreDictionary.registerOre("fenceWood");
 	}
 	
 	public boolean canPlaceTorchOnTop(IBlockState state, IBlockAccess worldIn, BlockPos pos) {

--- a/plantmegapack/block/PMPBlockWoodGate.java
+++ b/plantmegapack/block/PMPBlockWoodGate.java
@@ -32,5 +32,6 @@ public class PMPBlockWoodGate
 		setSoundType(SoundType.WOOD);
 		GameRegistry.registerBlock(this, blockName + suffix);
 		OreDictionary.registerOre(oreDictName + suffix, this);
+		OreDictionary.registerOre("fencegateWood");
 	}
 }

--- a/plantmegapack/block/PMPBlockWoodLadder.java
+++ b/plantmegapack/block/PMPBlockWoodLadder.java
@@ -29,5 +29,6 @@ public class PMPBlockWoodLadder
 		setSoundType(SoundType.WOOD);
 		GameRegistry.registerBlock(this, blockName + suffix);
 		OreDictionary.registerOre(oreDictName + suffix, this);
+		OreDictionary.registerOre("ladderWood");
 	}
 }

--- a/plantmegapack/block/PMPBlockWoodLog.java
+++ b/plantmegapack/block/PMPBlockWoodLog.java
@@ -43,6 +43,7 @@ public class PMPBlockWoodLog extends BlockLog {
 		setCreativeTab(PlantMegaPack.creativeTabs.getTab(PMPTab.item));
 		GameRegistry.registerBlock(this, blockName + "Block");
 		OreDictionary.registerOre(oreDictName + "Log", this);
+		OreDictionary.registerOre("logWood");
 	}
 	
 	protected BlockStateContainer createBlockState() {

--- a/plantmegapack/block/PMPBlockWoodPlanks.java
+++ b/plantmegapack/block/PMPBlockWoodPlanks.java
@@ -32,5 +32,6 @@ public class PMPBlockWoodPlanks
 		setCreativeTab(PlantMegaPack.creativeTabs.getTab(PMPTab.item));
 		GameRegistry.registerBlock(this, blockName + suffix);
 		OreDictionary.registerOre(blockName + suffix, this);
+		OreDictionary.registerOre("plankWood");
 	}
 }

--- a/plantmegapack/block/PMPBlockWoodSlab.java
+++ b/plantmegapack/block/PMPBlockWoodSlab.java
@@ -10,6 +10,7 @@ import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyBool;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
+import net.minecraftforge.oredict.OreDictionary;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
@@ -51,6 +52,7 @@ public abstract class PMPBlockWoodSlab
 		setHardness(1.2F);
 		setResistance(5.0F);
 		setSoundType(SoundType.WOOD);
+		OreDictionary.registerOre("slabWood");
 		setDefaultState(getDefaultState().withProperty(VARIANT, Boolean.valueOf(false)).withProperty(BlockSlab.HALF, isDouble() ? BlockSlab.EnumBlockHalf.TOP : BlockSlab.EnumBlockHalf.BOTTOM));
 		if (!isDouble()) {
 			setCreativeTab(PlantMegaPack.creativeTabs.getTab(PMPTab.item));

--- a/plantmegapack/block/PMPBlockWoodStairs.java
+++ b/plantmegapack/block/PMPBlockWoodStairs.java
@@ -34,5 +34,6 @@ public class PMPBlockWoodStairs
 		setCreativeTab(PlantMegaPack.creativeTabs.getTab(PMPTab.item));
 		GameRegistry.registerBlock(this, blockName + suffix);
 		OreDictionary.registerOre(oreDictName + suffix, this);
+		OreDictionary.registerOre("stairWood");
 	}
 }

--- a/plantmegapack/item/PMPItemSeed.java
+++ b/plantmegapack/item/PMPItemSeed.java
@@ -24,6 +24,7 @@ public class PMPItemSeed
 		setCreativeTab(CreativeTabs.MATERIALS);
 		GameRegistry.registerItem(this, this.seed.name());
 		OreDictionary.registerOre(this.seed.oreDictName, this);
+		OreDictionary.registerOre("listAllseed");
 	}
 	
 	public EnumPlantType getPlantType(IBlockAccess world, BlockPos pos) {


### PR DESCRIPTION
On a side note, you should probably do something about the oredictionary derpiness this mod has.

For instance, if I wanted to use a recipe that called for tomatoes for any mod that registered an oredictionary definition for them, I could use whole plants, which is not intended, and impossible for the most part, unless there is some magical way of getting fully grown tomato plants in your inventory without creative mode. I suggest fixing that, and adding some generic oredictionary definitions that encompass most plants as well.

Look at harvestcraft and how it does oredictionary definitions to fix this issue.
